### PR TITLE
Fix check args number psexec

### DIFF
--- a/Jump-exec/Psexec/psexec.py
+++ b/Jump-exec/Psexec/psexec.py
@@ -28,11 +28,11 @@ def psexec( demonID, *param ):
 
     demon = Demon( demonID )
 
-    if len(param) < 3:
+    if len(param) < 4:
         demon.ConsoleWrite( demon.CONSOLE_ERROR, "Not enough arguments" )
         return False
 
-    if len(param) > 3:
+    if len(param) > 4:
         demon.ConsoleWrite( demon.CONSOLE_ERROR, "Too many arguments" )
         return False
 


### PR DESCRIPTION
The number of arguments is 4 instead of 3, which makes it impossible to use the psexec command.