### PR TITLE
Fix Jump-exec wmi-proccreate

### DIFF
--- a/Jump-exec/WMI/ProcCreate/source/WMI-ProcessCreate.cpp
+++ b/Jump-exec/WMI/ProcCreate/source/WMI-ProcessCreate.cpp
@@ -8,7 +8,7 @@
 #include <windows.h>
 #include <stdio.h>
 #include <wbemcli.h>
-#include <comdef.h>
+//#include <comdef.h>
 #include <combaseapi.h>
 #pragma comment(lib, "wbemuuid.lib")
 #pragma comment(lib, "comsuppw.lib")
@@ -121,7 +121,7 @@ void go(char* buff, int len) {
 	CreateCreds(&authInfo, &authidentity, bwusername, bwpassword, bwdomain, IsCurrent);
 
 	// Doesnt currently work but should let you use current context
-	if (IsCurrent == 0)
+	if (IsCurrent == 1)
 	{
 	authidentity = NULL;
 	}

--- a/Jump-exec/WMI/wmi.py
+++ b/Jump-exec/WMI/wmi.py
@@ -106,7 +106,7 @@ def wmi_proccreate( demonID, *params ):
     packer.addWstr(command)
     packer.addbool(is_current)
 
-    TaskID = demon.ConsoleWrite( demon.CONSOLE_TASK, f"Tasked demon to run a VBS script in {target} via wmi" )
+    TaskID = demon.ConsoleWrite( demon.CONSOLE_TASK, f"Tasked demon to run command on {target} via wmi" )
 
     demon.InlineExecute( TaskID, "go", f"ProcCreate/bin/ProcCreate.{demon.ProcessArch}.o", packer.getbuffer(), False )
 


### PR DESCRIPTION
Fixes a couple errors thrown when using the wmi-proccreate subcommand of the Jump-exec module. Also updated the console output to accurately reflect what the subcommand does.

Before fix:
![Screenshot_20231212_144303](https://github.com/HavocFramework/Modules/assets/79864975/64a00a76-6a19-449a-8b7c-159b0057d382)

After fix:
![Screenshot_20231212_144001](https://github.com/HavocFramework/Modules/assets/79864975/13adde41-60c0-4ae6-a6da-c7ecbb8580a4)

Tested in a Debian 12 VM.